### PR TITLE
Fix Join group bug

### DIFF
--- a/api/src/JMP/Services/MembershipService.php
+++ b/api/src/JMP/Services/MembershipService.php
@@ -57,6 +57,7 @@ SQL;
         $sql = <<< SQL
             INSERT INTO membership (group_id, user_id) 
             VALUES (:groupId, :userId)
+            ON DUPLICATE KEY UPDATE group_id=group_id, user_id=user_id
 SQL;
 
         return $this->executeForEachUser($sql, $groupId, $users);

--- a/docs/api-v1.md
+++ b/docs/api-v1.md
@@ -614,7 +614,7 @@ Parameters:
 
 | Field | Description                         | Required |
 | ----- | ----------------------------------- | -------- |
-| users | One or more users to join the group | ✔️        |
+| users | One or more users to join the group | ✔        |
 
 Example request data:
 
@@ -626,7 +626,19 @@ Example request data:
 
 Access rights: authentication required, user has to be an admin
 
-Returns: the [Group](#Group)
+Returns: A [group](#Group) and [errors](#json-error-objects) with all invalid user id's which could not be added.
+````json
+{
+    "group": {
+        "id": 5,
+        "name": "Admin",
+        "users": []
+    },
+    "errors": {
+        "invalidUsers": "5,-1"
+    }
+}
+````
 
 ### Leave Group
 


### PR DESCRIPTION
Return an additional error message when trying to insert invalid user ids and prevents duplicate key errors when trying to add a already existing membership. Api-Specification is also updated.